### PR TITLE
setup.py: Specify encoding when opening files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@
 
 from __future__ import absolute_import
 from setuptools import setup, find_packages
+from io import open
 
-VERSION = open('VERSION', 'r').read()
+VERSION = open('VERSION', 'r', encoding='utf-8').read()
 VERSION = VERSION.replace('\n', '')
 
-CHANGES = open('doc/Changes', 'r').read()
+CHANGES = open('doc/Changes', 'r', encoding='utf-8').read()
 
 DOC = """
 WebDAV library for python3.


### PR DESCRIPTION
This makes setup.py work in environments where UTF-8 is not the default locale.

I ran into this on Fedora package builders; I suppose Windows would also be affected.
