### PR TITLE
Offer an HTML directory listing to HTTP clients

### DIFF
--- a/pywebdav/lib/WebDAVServer.py
+++ b/pywebdav/lib/WebDAVServer.py
@@ -232,7 +232,12 @@ class DAVRequestHandler(AuthServer.AuthRequestHandler, LockManager):
 
         # get the content type
         try:
-            content_type = dc.get_prop(uri, "DAV:", "getcontenttype")
+            if uri.endswith(b'/'):
+                # we could do away with this very non-local workaround for
+                # _get_listing if the data could have a type attached
+                content_type = 'text/html;charset=utf-8'
+            else:
+                content_type = dc.get_prop(uri, "DAV:", "getcontenttype")
         except DAV_NotFound:
             content_type = "application/octet-stream"
 


### PR DESCRIPTION
WebDAV clients should not be affected by this, but web browsers (which are nice for testing) now give more practical responses in tests.

(The previous behavior was to serve a plain 'Directory at b"path"' with a mime type unknown to browsers.)