### PR TITLE
Fix bytes/string mixups

### DIFF
--- a/pywebdav/lib/WebDAVServer.py
+++ b/pywebdav/lib/WebDAVServer.py
@@ -75,7 +75,7 @@ class DAVRequestHandler(AuthServer.AuthRequestHandler, LockManager):
         if DATA:
             if 'gzip' in self.headers.get('Accept-Encoding', '').split(',') \
                     and len(DATA) > self.encode_threshold:
-                buffer = io.StringIO()
+                buffer = io.BytesIO()
                 output = gzip.GzipFile(mode='wb', fileobj=buffer)
                 if isinstance(DATA, str) or isinstance(DATA, six.text_type):
                     output.write(DATA)
@@ -137,9 +137,9 @@ class DAVRequestHandler(AuthServer.AuthRequestHandler, LockManager):
         if DATA:
             if ('gzip' in self.headers.get('Accept-Encoding', '').split(',')
                 and len(DATA) > self.encode_threshold):
-                buffer = io.StringIO()
+                buffer = io.BytesIO()
                 output = gzip.GzipFile(mode='wb', fileobj=buffer)
-                if isinstance(DATA, str):
+                if isinstance(DATA, bytes):
                     output.write(DATA)
                 else:
                     for buf in DATA:

--- a/pywebdav/server/fshandler.py
+++ b/pywebdav/server/fshandler.py
@@ -132,7 +132,7 @@ class FilesystemHandler(dav_interface):
             if os.path.isfile(path):
                 file_size = os.path.getsize(path)
                 if range is None:
-                    fp=open(path,"r")
+                    fp=open(path,"rb")
                     log.info('Serving content of %s' % uri)
                     return Resource(fp, file_size)
                 else:
@@ -152,7 +152,7 @@ class FilesystemHandler(dav_interface):
                     if range[1] > file_size:
                         range[1] = file_size
 
-                    fp=open(path,"r")
+                    fp=open(path,"rb")
                     fp.seek(range[0])
                     log.info('Serving range %s -> %s content of %s' % (range[0], range[1], uri))
                     return Resource(fp, range[1] - range[0])


### PR DESCRIPTION
Typical exception obtained when accessing directory listings from GVFS:

    Exception happened during processing of request from ('127.0.0.1', 50674)
    Traceback (most recent call last):
      File "/usr/lib/python3.5/socketserver.py", line 625, in process_request_thread
        self.finish_request(request, client_address)
      File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
        self.RequestHandlerClass(request, client_address, self)
      File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
        self.handle()
      File "/usr/lib/python3.5/http/server.py", line 422, in handle
        self.handle_one_request()
      File "/usr/lib/python3.5/http/server.py", line 410, in handle_one_request
        method()
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 348, in do_PROPFIND
        'Multiple responses')
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 120, in send_body_chunks_if_http11
        self.send_body_chunks(DATA, code, msg, desc, ctype, headers)
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 141, in send_body_chunks
        output = gzip.GzipFile(mode='wb', fileobj=buffer)
      File "/usr/lib/python3.5/gzip.py", line 192, in __init__
        self._write_gzip_header()
      File "/usr/lib/python3.5/gzip.py", line 220, in _write_gzip_header
        self.fileobj.write(b'\037\213')             # magic header
    TypeError: string argument expected, got 'bytes'

Typical exception obtained when accessing text files from GVFS:

    Exception happened during processing of request from ('127.0.0.1', 50580)
    Traceback (most recent call last):
      File "/usr/lib/python3.5/socketserver.py", line 625, in process_request_thread
        self.finish_request(request, client_address)
      File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
        self.RequestHandlerClass(request, client_address, self)
      File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
        self.handle()
      File "/usr/lib/python3.5/http/server.py", line 422, in handle
        self.handle_one_request()
      File "/usr/lib/python3.5/http/server.py", line 410, in handle_one_request
        method()
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 281, in do_GET
        status_code = self._HEAD_GET(with_body=True)
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 266, in _HEAD_GET
        content_type, headers)
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 120, in send_body_chunks_if_http11
        self.send_body_chunks(DATA, code, msg, desc, ctype, headers)
      File "PyWebDAV3/pywebdav/lib/WebDAVServer.py", line 146, in send_body_chunks
        output.write(buf)
      File "/usr/lib/python3.5/gzip.py", line 258, in write
        data = memoryview(data)
    TypeError: memoryview: a bytes-like object is required, not 'str'