### PR TITLE
Fix double Content-Type header

### DIFF
--- a/pywebdav/lib/WebDAVServer.py
+++ b/pywebdav/lib/WebDAVServer.py
@@ -152,7 +152,6 @@ class DAVRequestHandler(AuthServer.AuthRequestHandler, LockManager):
                 self.send_header('Content-Encoding', 'gzip')
 
             self.send_header('Content-Length', len(DATA))
-            self.send_header('Content-Type', ctype)
 
         else:
             self.send_header('Content-Length', 0)


### PR DESCRIPTION
There should be only one Content-Type header in a message https://stackoverflow.com/questions/4371328/are-duplicate-http-response-headers-acceptable/4371395#4371395