### PR TITLE
Bugfix/gzip

### DIFF
--- a/pywebdav/lib/WebDAVServer.py
+++ b/pywebdav/lib/WebDAVServer.py
@@ -205,6 +205,8 @@ class DAVRequestHandler(AuthServer.AuthRequestHandler, LockManager):
                 content_type = 'text/html;charset=utf-8'
             else:
                 content_type = dc.get_prop(uri, "DAV:", "getcontenttype")
+                if content_type == 'httpd/unix-directory':
+                    content_type = 'text/html;charset=utf-8'
         except DAV_NotFound:
             content_type = "application/octet-stream"
 

--- a/pywebdav/server/fshandler.py
+++ b/pywebdav/server/fshandler.py
@@ -18,7 +18,7 @@ else:
 
 log = logging.getLogger(__name__)
 
-BUFFER_SIZE = 128 * 1000 
+BUFFER_SIZE = 128 * 1000
 # include magic support to correctly determine mimetypes
 MAGIC_AVAILABLE = False
 try:
@@ -53,10 +53,10 @@ class Resource(object):
 
         data = self.__fp.read(length)
         return data
-        
+
 
 class FilesystemHandler(dav_interface):
-    """ 
+    """
     Model a filesystem for DAV
 
     This class models a regular filesystem for the DAV server
@@ -68,6 +68,7 @@ class FilesystemHandler(dav_interface):
     to /tmp/gfx/pix
 
     """
+    index_files = ()
 
     def __init__(self, directory, uri, verbose=False):
         self.setDirectory(directory)
@@ -155,6 +156,16 @@ class FilesystemHandler(dav_interface):
 
         path=self.uri2local(uri)
         if os.path.exists(path):
+            if os.path.isdir(path):
+                for filename in self.index_files:
+                    new_path = os.path.join(path, filename)
+                    if os.path.isfile(new_path):
+                        path = new_path
+                        break
+                else:
+                    msg = self._get_listing(path)
+                    return Resource(StringIO(msg), len(msg))
+
             if os.path.isfile(path):
                 file_size = os.path.getsize(path)
                 if range is None:
@@ -182,9 +193,6 @@ class FilesystemHandler(dav_interface):
                     fp.seek(range[0])
                     log.info('Serving range %s -> %s content of %s' % (range[0], range[1], uri))
                     return Resource(fp, range[1] - range[0])
-            elif os.path.isdir(path):
-                msg = self._get_listing(path)
-                return Resource(StringIO(msg), len(msg))
             else:
                 # also raise an error for collections
                 # don't know what should happen then..
@@ -319,7 +327,7 @@ class FilesystemHandler(dav_interface):
             shutil.rmtree(path)
         except OSError:
             raise DAV_Forbidden # forbidden
-        
+
         return 204
 
     def rm(self,uri):
@@ -353,7 +361,7 @@ class FilesystemHandler(dav_interface):
         return delone(self,uri)
 
     def deltree(self,uri):
-        """ delete a collection 
+        """ delete a collection
 
         You have to return a result dict of the form
         uri:error_code


### PR DESCRIPTION
- I've fixed the gzip responses, which seemed to get wrong when the chunked transfer encoding was also on. It may however still need some work, to make the gzip chunked, and not just avoid doing a chunked response when it's gzipped.
- I've also fixed the MIME type for GET responses for directories, as the `httpd/unix-directory` makes no sense with a HTML listing of a directory.
- And as an alternative to those listings, I've added support for index.html files. It requires defining the name(s) of the index file(s), however, and by default is disabled.