### PR TITLE
test: fix invalid escape sequence

### DIFF
--- a/test/test_litmus.py
+++ b/test/test_litmus.py
@@ -72,7 +72,7 @@ class Test(unittest.TestCase):
             for line in lines:
                 line = line.split('\r')[-1]
                 result.append(line)
-                if len(re.findall('^ *\d+\.', line)):
+                if len(re.findall(r'^ *\d+\.', line)):
                     assert line.endswith('pass'), line
 
         finally:
@@ -107,7 +107,7 @@ class Test(unittest.TestCase):
             for line in lines:
                 line = line.split('\r')[-1]
                 result.append(line)
-                if len(re.findall('^ *\d+\.', line)):
+                if len(re.findall(r'^ *\d+\.', line)):
                     assert line.endswith('pass'), line
 
         finally:


### PR DESCRIPTION
Running the tests leads to

test/test_litmus.py:110
test/test_litmus.py:110: DeprecationWarning: invalid escape sequence '\d'
    if len(re.findall('^ *\d+\.', line)):

'\d' can appear in a regular expression but is invalid in a Unicode string.

Convert the Unicode string to a regular expression.